### PR TITLE
added: update transaction pin endpoint

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -138,6 +138,15 @@ export class UserController {
     }
 
     @UseGuards(UserAuthGuard)
+    @Put('change-trnsaction pin')
+    async updateUserTransactionPin(
+        @Body() body: ChangePinDto,
+        @UserDecorator() users: any,
+    ) {
+        return await this.userService.updateTransactionPin(body, users.userId);
+    }
+
+    @UseGuards(UserAuthGuard)
     @Get('beneficaries/me')
     async getUserBeneficaries(@UserDecorator() users: any) {
         return await this.userService.viewAllUserBeneficiaries(users.userId);


### PR DESCRIPTION
- added a ```PUT``` endpoint for updating transaction pin
- prevented a single point of failure in user credentials by making sure pins and transactions pins are only updated at their specific endpoints